### PR TITLE
Mark "binding expressions" as supported in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ website at https://openjfx.io/javadoc/21/javafx.fxml/javafx/fxml/doc-files/intro
 
 The following aspects are not yet implemented from the spec:
 
-* Binding expressions
 * Location resolution
 * Event handler expressions
 


### PR DESCRIPTION
Mark "binding expressions" as supported in README. Support seems to have been added in 79fe37a7106ccd8330a576d090311c82f58c15bd.